### PR TITLE
Expire contribution values appropriately

### DIFF
--- a/src/genegraph/source/graphql/contribution.clj
+++ b/src/genegraph/source/graphql/contribution.clj
@@ -3,11 +3,11 @@
             [genegraph.source.graphql.common.cache :refer [defresolver]]
             [clojure.string :as s]))
 
-(defresolver agent [args value]
+(defresolver ^:expire-by-value agent [args value]
   (ld1-> value [:sepio/has-agent]))
 
-(defresolver realizes [args value]
+(defresolver ^:expire-by-value realizes [args value]
   (ld1-> value [:bfo/realizes]))
 
-(defresolver date [args value]
+(defresolver ^:expire-by-value date [args value]
   (ld1-> value [:sepio/activity-date]))


### PR DESCRIPTION
PR to address issue when GV curations change the GCEP they are affiliated with, the attribution on the contributions change, but the cache is not set to expire. This changes this so that cache references expire when the referenced object is updated.