### PR TITLE
Added allowances for assertion_ prefix in GV iris

### DIFF
--- a/src/genegraph/main.clj
+++ b/src/genegraph/main.clj
@@ -85,3 +85,7 @@
       (= "snapshot" (first args)) (apply snapshot/-main2 (rest args))
       (= "vrs-cache" (first args)) (apply vrs-registry/-main (rest args))
       :else (run-migration))))
+
+(comment
+  (run-dev)
+  )

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -23,8 +23,14 @@
       (when (q/is-rdf-type? gciex-assertion :sepio/GeneValidityEvidenceLevelAssertion)
         gciex-assertion))))
 
+(defn phil-requested-assertion_be-ok-in-iris [iri]
+  (s/replace iri #"assertion_([0-9a-f\-]{36}).*" "$1"))
+
 (defresolver gene-validity-assertion-query [args value]
-  (let [requested-assertion (q/resource (:iri args))]
+  (let [requested-assertion (-> args
+                                :iri
+                                phil-requested-assertion_be-ok-in-iris
+                                q/resource)]
     (if (q/is-rdf-type? requested-assertion :sepio/GeneValidityEvidenceLevelAssertion)
       requested-assertion
       (or (q/ld1-> requested-assertion [[:cg/website-legacy-id :<]])

--- a/src/genegraph/source/graphql/schema/resource.clj
+++ b/src/genegraph/source/graphql/schema/resource.clj
@@ -118,6 +118,9 @@
    :resolve (fn [context args value]
               (q/resource (:iri args)))})
 
+(defn phil-requested-assertion_be-ok-in-iris [iri]
+  (s/replace iri #"assertion_([0-9a-f\-]{36}).*" "$1"))
+
 (def resource-query
   {:name :resource
    :graphql-type :query
@@ -125,5 +128,4 @@
    :args {:iri {:type 'String}}
    :type :Resource
    :resolve (fn [_ args _]
-              (let [r (q/resource (:iri args))]
-                (or (q/ld1-> r [[:cg/website-legacy-id :<]]) r)))})
+              (-> args :iri phil-requested-assertion_be-ok-in-iris q/resource))})


### PR DESCRIPTION
Per Phil's request on Slack:

Phillip Weller
  16 days ago
I'm probably imagining things - but didn't genegraaph used to return the current GVD record if you passed in an identifier without the timestamp?

8 replies

Tristan Nelson
  16 days ago
It does, but it doesn't seem to be happy if you add the assertion_ prefix. This link works, for example: https://search.clinicalgenome.org/kb/gene-validity/CGGV:38729563-bf36-48ae-929e-fa69a225de39

Phillip Weller
  16 days ago
How difficult would it be to also honor the current string format?

Tristan Nelson
  16 days ago
Including the assertion_ prefix before the UUID, you mean?

Phillip Weller
  16 days ago
Yes, the one currently in use.

Tristan Nelson
  16 days ago
I don't think it would be too bad. Is there something specific you're trying to accomplish with a particular timeframe?

Phillip Weller
  16 days ago
It would be nice if it could do maybe by the 15th of march?  Thats when we'll be freezing the code for the Q1 update.  Trying to implement a request for Jonathan and it requires always accessing the latest of whatever assertion he bookmarked.

Tristan Nelson
  16 days ago
That seems feasible, will let you know if that turns out to be a problem.

Phillip Weller
  16 days ago
Thanks!